### PR TITLE
chore: @tanstack/react-query 설정

### DIFF
--- a/apps/client/src/app/providers.tsx
+++ b/apps/client/src/app/providers.tsx
@@ -2,21 +2,19 @@
 
 import { CacheProvider } from "@chakra-ui/next-js";
 import { ChakraProvider } from "@chakra-ui/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { useState, type PropsWithChildren } from "react";
+import { type PropsWithChildren } from "react";
 
 import initMocks from "../mocks";
+import { QueryClientProvider } from "./shared/server";
 
 if (process.env.NEXT_PUBLIC_API_MOCKING === "enable") {
   initMocks();
 }
 
 export const Providers = ({ children }: PropsWithChildren) => {
-  const [queryClient] = useState(() => new QueryClient());
-
   return (
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider>
       <CacheProvider>
         <ChakraProvider>{children}</ChakraProvider>
       </CacheProvider>

--- a/apps/client/src/app/shared/server/index.ts
+++ b/apps/client/src/app/shared/server/index.ts
@@ -1,0 +1,2 @@
+export * from "./queryKeys";
+export * from "./tanstack";

--- a/apps/client/src/app/shared/server/tanstack/PrefetchHydration.tsx
+++ b/apps/client/src/app/shared/server/tanstack/PrefetchHydration.tsx
@@ -1,0 +1,18 @@
+import type { QueryFunction, QueryKey } from "@tanstack/react-query";
+import { Hydrate, QueryClient, dehydrate } from "@tanstack/react-query";
+import { cache, type PropsWithChildren } from "react";
+
+interface FetchQueryOptions {
+  queryKey: QueryKey;
+  queryFn: QueryFunction;
+}
+
+export const PrefetchHydration = async ({ queryKey, queryFn, children }: PropsWithChildren<FetchQueryOptions>) => {
+  const getQueryClient = cache(() => new QueryClient());
+  const queryClient = getQueryClient();
+
+  await queryClient.prefetchQuery({ queryKey, queryFn });
+  const dehydratedState = dehydrate(queryClient);
+
+  return <Hydrate state={dehydratedState}>{children}</Hydrate>;
+};

--- a/apps/client/src/app/shared/server/tanstack/QueryClientProvider.tsx
+++ b/apps/client/src/app/shared/server/tanstack/QueryClientProvider.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import type { QueryClientConfig } from "@tanstack/react-query";
+import { QueryClientProvider as BaseQueryClientProvider, QueryClient } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import type { PropsWithChildren } from "react";
+import { useState } from "react";
+
+const queryClientOption: QueryClientConfig = {
+  defaultOptions: {
+    queries: {
+      retry: false,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+    },
+  },
+};
+
+export const QueryClientProvider = ({ children }: PropsWithChildren) => {
+  const [queryClient] = useState(() => new QueryClient(queryClientOption));
+
+  return (
+    <BaseQueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools />
+    </BaseQueryClientProvider>
+  );
+};

--- a/apps/client/src/app/shared/server/tanstack/index.ts
+++ b/apps/client/src/app/shared/server/tanstack/index.ts
@@ -1,0 +1,1 @@
+export * from "./QueryClientProvider";

--- a/apps/client/src/app/shared/server/tanstack/index.ts
+++ b/apps/client/src/app/shared/server/tanstack/index.ts
@@ -1,1 +1,2 @@
+export * from "./PrefetchHydration";
 export * from "./QueryClientProvider";


### PR DESCRIPTION
# Describe your changes

- QueryClientProvider 분리
- prefetch & hydration에 필요한 기능 컴포넌트 모듈화
- [공식문서 - app router에서의 SSR (v4)](https://tanstack.com/query/v4/docs/react/guides/ssr#using-the-app-directory-in-nextjs-13) 참고했습니다 😀

## Issue ticket number and link (optional)

## Checklist

- [x] 🤔 이 프로젝트의 스타일 가이드를 따르나요?
- [x] 🤔 머지하기 전에 스스로 코드에 문제가 없음을 확인했나요?
- [x] 🤔 필요한 주석을 필요한 곳에 넣어주었나요?
- [x] ⛔️ (필수) base 브랜치를 pull 받았나요?!

## Next Step Todo (optional)

## Screenshots (optional)

## Questions

- 💬 질문 사항이에요!
- 🤷‍♂️ 확인 받고 싶은 부분이에요!
- 🔥 이건 꼭 확인해주세요!

[제가 next.js에서 react-query SSR 공부할 때 많이 참고했던 프로젝트](https://github.com/depromeet/InsightOut-client/blob/main/src/app/resumes/%40aside/default.tsx#L10) 중 일부분인데요!

SSR 통해 prefetch → 서버 컴포넌트에서 `PrefetchHydration` 를 통해 **dehydrate** → children으로 있는 클라이언트 컴포넌트에서 `동일한 queryKey를 사용`하여 **rehydrate** 과정이라고 간단하게 설명할 수 있을 거 같아요!
