### PR TITLE
Modal에서 onComfirm을 넘기지 않았을 때는 확인 클릭 시 닫히는 기능만 할 수 있도록

### DIFF
--- a/packages/ui/src/Modal/Modal.types.ts
+++ b/packages/ui/src/Modal/Modal.types.ts
@@ -3,7 +3,7 @@ export interface ModalProps {
   props: {
     type: "positive" | "negative" | "warning";
     title: string;
-    onConfirm: VoidFunction;
+    onConfirm?: VoidFunction;
   };
   onClose: VoidFunction;
 }

--- a/packages/ui/src/Modal/components/ModalFooter.tsx
+++ b/packages/ui/src/Modal/components/ModalFooter.tsx
@@ -6,7 +6,7 @@ export const ModalFooter = ({ props, onClose }: Pick<ModalProps, "props" | "onCl
   const { type, onConfirm } = props;
 
   const onConfirmAndClose = () => {
-    onConfirm();
+    if (onConfirm) onConfirm();
     onClose();
   };
 


### PR DESCRIPTION
# Describe your changes

Modal을 사용할 때 `확인` 버튼을 누르면 닫히는 기능만 해야될 때가 필요한 거 같더라구요.
그래서 onConfirm을 넘기지 않으면 별다른 액션 없이 닫히는 액션만도 할 수 있도록 했습니다~!

## Issue ticket number and link (optional)

## Checklist

- [x] 🤔 이 프로젝트의 스타일 가이드를 따르나요?
- [x] 🤔 머지하기 전에 스스로 코드에 문제가 없음을 확인했나요?
- [x] 🤔 필요한 주석을 필요한 곳에 넣어주었나요?
- [x] ⛔️ (필수) base 브랜치를 pull 받았나요?!

## Next Step Todo (optional)

## Screenshots (optional)

## Questions

- 💬 질문 사항이에요!
- 🤷‍♂️ 확인 받고 싶은 부분이에요!
- 🔥 이건 꼭 확인해주세요!
