### PR TITLE
API 작성시, 클라이언트에서 사용하는 응답 타입과 요청 타입을 http 메서드 제네릭으로 전달합니다.

### DIFF
--- a/apps/client/src/app/auth/_state/server/api.ts
+++ b/apps/client/src/app/auth/_state/server/api.ts
@@ -12,7 +12,7 @@ export const signUpApi = {
 export const API_LOGIN = {
   // TODO: 테스트 작업이며, 변경될 수 있는 사항입니다.
   Request: async ({ email, password }: SignInFormValues) => {
-    const { data } = await axiosInstance().post<SignInResponse>("/auth/login", {
+    const { data } = await axiosInstance<SignInResponse>().post("/auth/login", {
       email,
       password,
     });

--- a/apps/client/src/app/auth/_state/server/api.ts
+++ b/apps/client/src/app/auth/_state/server/api.ts
@@ -12,7 +12,8 @@ export const signUpApi = {
 export const API_LOGIN = {
   // TODO: 테스트 작업이며, 변경될 수 있는 사항입니다.
   Request: async ({ email, password }: SignInFormValues) => {
-    const { data } = await axiosInstance<SignInResponse>().post("/auth/login", {
+    // http 메서드 제네릭 인자로 응답 타입과 요청 타입 2가지를 전달하여 사용합니다.
+    const { data } = await axiosInstance().post<SignInResponse, SignInFormValues>("/auth/login", {
       email,
       password,
     });

--- a/apps/client/src/app/auth/_types/signInResponse.type.ts
+++ b/apps/client/src/app/auth/_types/signInResponse.type.ts
@@ -1,4 +1,5 @@
 export interface SignInResponse {
   // TODO: 테스트 작업이며, 변경될 수 있는 사항입니다.
-  result: { accessToken: string; refreshToken: string };
+  accessToken: string;
+  refreshToken: string;
 }

--- a/apps/client/src/app/shared/server/axios/axios.ts
+++ b/apps/client/src/app/shared/server/axios/axios.ts
@@ -4,8 +4,9 @@ import type { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from "axio
 import axios from "axios";
 import Cookies from "js-cookie";
 import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from "../constants";
+import type { BaseResponse } from "../types";
 
-export const axiosInstance = () => {
+export const axiosInstance = <T>() => {
   const accessToken = Cookies.get(ACCESS_TOKEN_KEY);
 
   const instanceConfig = {
@@ -31,7 +32,7 @@ export const axiosInstance = () => {
     );
 
     createAxiosInstance.interceptors.response.use(
-      (response: AxiosResponse) => {
+      (response: AxiosResponse<BaseResponse<T>>) => {
         return response;
       },
       async (error: AxiosError) => {
@@ -59,7 +60,7 @@ export const axiosInstance = () => {
   }
 
   createAxiosInstance.interceptors.response.use(
-    (response: AxiosResponse) => {
+    (response: AxiosResponse<BaseResponse<T>>) => {
       return response;
     },
     (error: AxiosError) => {

--- a/apps/client/src/app/shared/server/axios/axios.ts
+++ b/apps/client/src/app/shared/server/axios/axios.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-import type { AxiosError, AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from "axios";
+import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from "axios";
 import axios from "axios";
 
 import Cookies from "js-cookie";
@@ -23,9 +23,10 @@ export const axiosInstance = () => {
   const createAxiosInstance: AxiosInstance = axios.create(instanceConfig);
 
   const axiosInstance = {
-    get: <T, R>(url: string, params: R): Promise<AxiosResponse<BaseResponse<T>>> =>
+    get: <T, R>(url: string, params?: R): Promise<AxiosResponse<BaseResponse<T>>> =>
       createAxiosInstance.get(url, { params }),
-    post: <T, R>(url: string, body: R): Promise<AxiosResponse<BaseResponse<T>>> => createAxiosInstance.post(url, body),
+    post: <T, R>(url: string, body: R, headers?: AxiosRequestConfig<R>): Promise<AxiosResponse<BaseResponse<T>>> =>
+      createAxiosInstance.post(url, body, headers),
   };
 
   if (accessToken) {

--- a/apps/client/src/app/shared/server/axios/axios.ts
+++ b/apps/client/src/app/shared/server/axios/axios.ts
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-import type { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from "axios";
+import type { AxiosError, AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from "axios";
 import axios from "axios";
+
 import Cookies from "js-cookie";
 import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from "../constants";
 import type { BaseResponse } from "../types";
 
-export const axiosInstance = <T>() => {
+export const axiosInstance = () => {
   const accessToken = Cookies.get(ACCESS_TOKEN_KEY);
 
   const instanceConfig = {
@@ -19,7 +20,13 @@ export const axiosInstance = <T>() => {
     timeout: 5000,
   };
 
-  const createAxiosInstance = axios.create(instanceConfig);
+  const createAxiosInstance: AxiosInstance = axios.create(instanceConfig);
+
+  const axiosInstance = {
+    get: <T, R>(url: string, params: R): Promise<AxiosResponse<BaseResponse<T>>> =>
+      createAxiosInstance.get(url, { params }),
+    post: <T, R>(url: string, body: R): Promise<AxiosResponse<BaseResponse<T>>> => createAxiosInstance.post(url, body),
+  };
 
   if (accessToken) {
     createAxiosInstance.interceptors.request.use(
@@ -32,7 +39,7 @@ export const axiosInstance = <T>() => {
     );
 
     createAxiosInstance.interceptors.response.use(
-      (response: AxiosResponse<BaseResponse<T>>) => {
+      (response: AxiosResponse) => {
         return response;
       },
       async (error: AxiosError) => {
@@ -60,7 +67,7 @@ export const axiosInstance = <T>() => {
   }
 
   createAxiosInstance.interceptors.response.use(
-    (response: AxiosResponse<BaseResponse<T>>) => {
+    (response: AxiosResponse) => {
       return response;
     },
     (error: AxiosError) => {
@@ -68,5 +75,5 @@ export const axiosInstance = <T>() => {
     },
   );
 
-  return createAxiosInstance;
+  return axiosInstance;
 };

--- a/apps/client/src/app/shared/server/types/baseResponse.type.ts
+++ b/apps/client/src/app/shared/server/types/baseResponse.type.ts
@@ -1,0 +1,3 @@
+export interface BaseResponse<T> {
+  result: T;
+}

--- a/apps/client/src/app/shared/server/types/index.ts
+++ b/apps/client/src/app/shared/server/types/index.ts
@@ -1,0 +1,1 @@
+export * from "./baseResponse.type";


### PR DESCRIPTION
# Describe your changes
- AxiosReponse 응답 객체 data의 타입을 BaseResponse<T>으로 설정합니다.
  - 응답 객체 data : { result : T }
- 로그인 API에 테스트 합니다.

## Issue ticket number and link (optional)

## Checklist

- [x] 🤔 이 프로젝트의 스타일 가이드를 따르나요?
- [x] 🤔 머지하기 전에 스스로 코드에 문제가 없음을 확인했나요?
- [x] 🤔 필요한 주석을 필요한 곳에 넣어주었나요?
- [x] ⛔️ (필수) base 브랜치를 pull 받았나요?!

## Next Step Todo (optional)

## Screenshots (optional)

## Questions

- 💬 질문 사항이에요!
- 🤷‍♂️ 확인 받고 싶은 부분이에요!
- 🔥 이건 꼭 확인해주세요!
