### PR TITLE
api 요청 시 BaseResponse 타입을 래핑할 수 있도록

### DIFF
--- a/apps/client/src/app/auth/_state/server/api.ts
+++ b/apps/client/src/app/auth/_state/server/api.ts
@@ -1,7 +1,6 @@
 import type { SignInFormValues, SignInResponse } from "@auth/_types";
 import axios from "axios";
-import axiosInstance from "~/app/shared/server/axios/axios";
-import type { BaseResponse } from "~/app/shared/server/types";
+import { api } from "~/app/shared/server";
 
 export const signUpApi = {
   signUpResponse: (postData: object) => {
@@ -11,11 +10,8 @@ export const signUpApi = {
 
 export const API_LOGIN = {
   // TODO: 테스트 작업이며, 변경될 수 있는 사항입니다.
-  Request: async ({ email, password }: SignInFormValues) => {
-    const { data } = await axiosInstance.post<BaseResponse<SignInResponse>>("/auth/login", {
-      email,
-      password,
-    });
+  Request: async (value: SignInFormValues) => {
+    const { data } = await api.post<SignInResponse>("/auth/login", value);
 
     return data.result;
   },

--- a/apps/client/src/app/auth/_state/server/api.ts
+++ b/apps/client/src/app/auth/_state/server/api.ts
@@ -1,7 +1,7 @@
-import type { SignInFormValues } from "@auth/_types";
-import type { SignInResponse } from "@auth/_types/signInResponse.type";
+import type { SignInFormValues, SignInResponse } from "@auth/_types";
 import axios from "axios";
-import { axiosInstance } from "~/app/shared/server";
+import axiosInstance from "~/app/shared/server/axios/axios";
+import type { BaseResponse } from "~/app/shared/server/types";
 
 export const signUpApi = {
   signUpResponse: (postData: object) => {
@@ -12,7 +12,7 @@ export const signUpApi = {
 export const API_LOGIN = {
   // TODO: 테스트 작업이며, 변경될 수 있는 사항입니다.
   Request: async ({ email, password }: SignInFormValues) => {
-    const { data } = await axiosInstance().post<SignInResponse>("/auth/login", {
+    const { data } = await axiosInstance.post<BaseResponse<SignInResponse>>("/auth/login", {
       email,
       password,
     });

--- a/apps/client/src/app/auth/_types/signInResponse.type.ts
+++ b/apps/client/src/app/auth/_types/signInResponse.type.ts
@@ -1,4 +1,4 @@
 export interface SignInResponse {
-  // TODO: 테스트 작업이며, 변경될 수 있는 사항입니다.
-  result: { accessToken: string; refreshToken: string };
+  accessToken: string;
+  refreshToken: string;
 }

--- a/apps/client/src/app/shared/server/axios/axios.ts
+++ b/apps/client/src/app/shared/server/axios/axios.ts
@@ -4,6 +4,7 @@ import type { AxiosError, AxiosInstance, AxiosResponse, InternalAxiosRequestConf
 import axios from "axios";
 import Cookies from "js-cookie";
 import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from "../constants";
+import type { BaseResponse } from "../types";
 
 const accessToken = Cookies.get(ACCESS_TOKEN_KEY);
 
@@ -66,4 +67,20 @@ axiosInstance.interceptors.response.use(
   },
 );
 
-export default axiosInstance;
+export const api = {
+  get: <T>(...args: Parameters<typeof axiosInstance.get>) => {
+    return axiosInstance.get<BaseResponse<T>>(...args);
+  },
+  post: <T>(...args: Parameters<typeof axiosInstance.post>) => {
+    return axiosInstance.post<BaseResponse<T>>(...args);
+  },
+  put: <T>(...args: Parameters<typeof axiosInstance.put>) => {
+    return axiosInstance.put<BaseResponse<T>>(...args);
+  },
+  patch: <T>(...args: Parameters<typeof axiosInstance.patch>) => {
+    return axiosInstance.patch<BaseResponse<T>>(...args);
+  },
+  delete: <T>(...args: Parameters<typeof axiosInstance.delete>) => {
+    return axiosInstance.delete<BaseResponse<T>>(...args);
+  },
+};

--- a/apps/client/src/app/shared/server/axios/axios.ts
+++ b/apps/client/src/app/shared/server/axios/axios.ts
@@ -1,71 +1,69 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-import type { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from "axios";
+import type { AxiosError, AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from "axios";
 import axios from "axios";
 import Cookies from "js-cookie";
 import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from "../constants";
 
-export const axiosInstance = () => {
-  const accessToken = Cookies.get(ACCESS_TOKEN_KEY);
+const accessToken = Cookies.get(ACCESS_TOKEN_KEY);
 
-  const instanceConfig = {
-    baseURL: "/api",
-    headers: {
-      "Content-Type": "application/json",
-      ...((accessToken && { "Authorization": `Bearer ${accessToken}` }) ?? {}),
-    },
-    withCredentials: true,
-    timeout: 5000,
-  };
+const instanceConfig = {
+  baseURL: "/api",
+  headers: {
+    "Content-Type": "application/json",
+    ...((accessToken && { "Authorization": `Bearer ${accessToken}` }) ?? {}),
+  },
+  withCredentials: true,
+  timeout: 5000,
+};
 
-  const createAxiosInstance = axios.create(instanceConfig);
+const axiosInstance: AxiosInstance = axios.create(instanceConfig);
 
-  if (accessToken) {
-    createAxiosInstance.interceptors.request.use(
-      (config: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
-        return config;
-      },
-      (error: AxiosError) => {
-        return Promise.reject(error);
-      },
-    );
-
-    createAxiosInstance.interceptors.response.use(
-      (response: AxiosResponse) => {
-        return response;
-      },
-      async (error: AxiosError) => {
-        const _err = error;
-        const originalReqConfig = error?.config;
-
-        if (_err.status === 401 && REFRESH_TOKEN_KEY) {
-          try {
-            const res = await createAxiosInstance.post(`/auth/reissue`, { REFRESH_TOKEN_KEY });
-            const reIssuedAccessToken: string = await res?.data?.result?.accessToken;
-
-            if (reIssuedAccessToken) {
-              originalReqConfig!.headers.Authorization = `Bearer ${reIssuedAccessToken}`;
-
-              return createAxiosInstance(originalReqConfig as InternalAxiosRequestConfig);
-            }
-          } catch (refreshError) {
-            return Promise.reject(refreshError);
-          }
-        }
-
-        return Promise.reject(error);
-      },
-    );
-  }
-
-  createAxiosInstance.interceptors.response.use(
-    (response: AxiosResponse) => {
-      return response;
+if (accessToken) {
+  axiosInstance.interceptors.request.use(
+    (config: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
+      return config;
     },
     (error: AxiosError) => {
       return Promise.reject(error);
     },
   );
 
-  return createAxiosInstance;
-};
+  axiosInstance.interceptors.response.use(
+    (response: AxiosResponse) => {
+      return response;
+    },
+    async (error: AxiosError) => {
+      const _err = error;
+      const originalReqConfig = error?.config;
+
+      if (_err.status === 401 && REFRESH_TOKEN_KEY) {
+        try {
+          const res = await axiosInstance.post(`/auth/reissue`, { REFRESH_TOKEN_KEY });
+          const reIssuedAccessToken: string = await res?.data?.result?.accessToken;
+
+          if (reIssuedAccessToken) {
+            originalReqConfig!.headers.Authorization = `Bearer ${reIssuedAccessToken}`;
+
+            return axiosInstance(originalReqConfig as InternalAxiosRequestConfig);
+          }
+        } catch (refreshError) {
+          return Promise.reject(refreshError);
+        }
+      }
+
+      return Promise.reject(error);
+    },
+  );
+}
+
+axiosInstance.interceptors.response.use(
+  (response: AxiosResponse) => {
+    return response;
+  },
+  (error: AxiosError) => {
+    return Promise.reject(error);
+  },
+);
+
+export default axiosInstance;

--- a/apps/client/src/app/shared/server/types/baseResponse.types.ts
+++ b/apps/client/src/app/shared/server/types/baseResponse.types.ts
@@ -1,0 +1,3 @@
+export interface BaseResponse<T> {
+  result: T;
+}

--- a/apps/client/src/app/shared/server/types/index.ts
+++ b/apps/client/src/app/shared/server/types/index.ts
@@ -1,0 +1,1 @@
+export type * from "./baseResponse.types";


### PR DESCRIPTION
# Describe your changes

#56 내용 확인했을 떄 제가 원하는 방향은 이런 방향이였어서 PR 새로 올려보았어요. 둘 중 하나로 결정해서 하나는 close하면 될 거 같습니다~
- axiosInstance 수정
- 래핑용 BaseResponse 타입 추가
- signIn api에 예시로 적용

로그인을 위한 query를 예시로 하나 적어봤어요! 요청도 잘 되더라구요 !
```tsx
// Usage

const useLogin = () => {
    return useMutation({
      mutationFn: ({ email, password }: SignInFormValues) => API_LOGIN.Request({ email, password }),
      onSuccess: (data) => { // 타입 추론도 됩니당
        const { accessToken } = data;
        Cookies.set(ACCESS_TOKEN_KEY, accessToken);
      },
    });
  };

  const { mutate } = useLogin();

  const onSubmitHandler = (data: SignInFormValues) => {
    mutate(data);
  };
```
## Issue ticket number and link (optional)

## Checklist

- [x] 🤔 이 프로젝트의 스타일 가이드를 따르나요?
- [x] 🤔 머지하기 전에 스스로 코드에 문제가 없음을 확인했나요?
- [x] 🤔 필요한 주석을 필요한 곳에 넣어주었나요?
- [x] ⛔️ (필수) base 브랜치를 pull 받았나요?!

## Next Step Todo (optional)

## Screenshots (optional)

## Questions

- 💬 질문 사항이에요!
- 🤷‍♂️ 확인 받고 싶은 부분이에요!
- 🔥 이건 꼭 확인해주세요!
