### PR TITLE
스토리북 실행 후 .storybook > preview.tsx 에서 속성값 재정의 에러 수정

### DIFF
--- a/apps/workshop/.storybook/preview.tsx
+++ b/apps/workshop/.storybook/preview.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 const OriginalNextImage = NextImage.default;
 
-Object.defineProperty(NextImage, "default", {
+Object.defineProperty(NextImage, "initialState", {
   configurable: true,
   value: (props) => <OriginalNextImage {...props} unoptimized />,
 });


### PR DESCRIPTION
# Describe your changes
- NextImage의 속성값을 'initialState'로 수정
```
Object.defineProperty(NextImage, "initialState", {
  configurable: true,
  value: (props) => <OriginalNextImage {...props} unoptimized />,
});
```

- 에러 메시지
```
Cannot redefine property: default

TypeError: Cannot redefine property: default
    at Function.defineProperty (<anonymous>)
    at http://localhost:6006/.storybook/preview.tsx?t=1707965692057:5:8
```

## Issue ticket number and link (optional)

## Checklist

- [x] 🤔 이 프로젝트의 스타일 가이드를 따르나요?
- [x] 🤔 머지하기 전에 스스로 코드에 문제가 없음을 확인했나요?
- [x] 🤔 필요한 주석을 필요한 곳에 넣어주었나요?
- [x] ⛔️ (필수) base 브랜치를 pull 받았나요?!

## Next Step Todo (optional)

## Screenshots (optional)

## Questions

- 💬 질문 사항이에요!
- 🤷‍♂️ 스토리북 실행시에 타입 에러로 위와 같은 경우가 동일하게 발생되는지 확인 부탁드립니다.
- 🔥 이건 꼭 확인해주세요!
